### PR TITLE
xFormers cuda missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,13 @@ python svg_render.py x=svgdreamer "prompt='a panda rowing a boat in a pond. mini
 <p align="right"><a href="#ptsvg"><sup>▴ Back to top</sup></a></p>
 
 - Q: Where can I get more scripts and visualizations?
-- A: check the [pytorch-svgrender.readthedocs.io](https://pytorch-svgrender.readthedocs.io/en/latest/index.html).
+- A: Check the [pytorch-svgrender.readthedocs.io](https://pytorch-svgrender.readthedocs.io/en/latest/index.html).
 
 - Q: An error says HuggingFace cannot find the model in the disk cache.
 - A: Add *`diffuser.download=True`* to the command for downloading model checkpoints the **first time** you run the script.
+
+- Q: It says xFormers is not built with CUDA support or xFormers cannot load C++/CUDA extensions.
+- A: You need to install xFormers again using the command *`pip install --pre -U xformers`* instead of the conda one.
 
 <h2 align="center">TODO</h2>
 <p align="right"><a href="#ptsvg"><sup>▴ Back to top</sup></a></p>

--- a/script/install.sh
+++ b/script/install.sh
@@ -40,7 +40,8 @@ echo "CLIP installation is complete."
 pip install diffusers==0.20.2
 
 echo "Diffusers installation is complete. version: 0.20.2"
-
+# if xformers doesnt install properly with conda try installing with pip using the code below
+# pip install --pre -U xformers
 conda install xformers -c xformers
 
 echo "xformers installation is complete."


### PR DESCRIPTION
Hi Ximing and team! 

There was a small problem after running svgdreamer on ubuntu 22.04.  I got a warning and error from xFormers that it  could not load CUDA extensions. Please see the images below:

xFormers warning:
![Screenshot from 2024-03-09 21-08-05](https://github.com/ximinng/PyTorch-SVGRender/assets/61637151/22f148b6-63ad-4c06-841b-50bd682087bd)

xFormers error: 
![image](https://github.com/ximinng/PyTorch-SVGRender/assets/61637151/271ef7cb-1f33-4ef8-8ed0-8f913b6b1258)

It gave this error saying xFormers was not built with CUDA support. After, further investigating the warning it seems it was because of the cudatoolkit I had installed globally which is 12.1. Instead of downgrading the cudatoolkit, I just installed the development libraries for xFormers which supports cudatookit 12. 

To avoid anyone else facing the same issue, this pull request adds `pip install --pre -U xformers` as a commented line in the install.sh script and I have also added this in the FAQ section of the readme. 


I have tested this and this works, heres an image of it working:

![image](https://github.com/ximinng/PyTorch-SVGRender/assets/61637151/a8c2af8a-9e8f-4aef-874c-a8bf3b845f37)


